### PR TITLE
Revert 10sec delay

### DIFF
--- a/pkg/consensus/clock.go
+++ b/pkg/consensus/clock.go
@@ -46,8 +46,7 @@ func (c *Clock) TickSlots(ctx context.Context) chan types.Slot {
 			currentSlot := c.CurrentSlot(now)
 			ch <- currentSlot
 			nextSlot := currentSlot + 1
-			// Adding 10seconds delay to get it closer to when validators query relays
-			nextSlotStart := c.SlotInSeconds(nextSlot) + 10
+			nextSlotStart := c.SlotInSeconds(nextSlot)
 			duration := time.Duration(nextSlotStart - now)
 			select {
 			case <-time.After(duration * time.Second):


### PR DESCRIPTION
@Ross-Kitsis Reverting the 10sec delay since most querying happens at the start and not the end of the slot