### PR TITLE
Validator Cleanup

### DIFF
--- a/cmd/relay-monitor/main.go
+++ b/cmd/relay-monitor/main.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ralexstokes/relay-monitor/pkg/config"
 	"github.com/ralexstokes/relay-monitor/pkg/monitor"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -38,23 +39,23 @@ func main() {
 		logger.Fatalf("could not read config file: %v", err)
 	}
 
-	config := &monitor.Config{}
-	err = yaml.Unmarshal(data, config)
+	appConf := &config.Config{}
+	err = yaml.Unmarshal(data, appConf)
 	if err != nil {
 		logger.Fatalf("could not load config: %v", err)
 	}
 
 	// parse bootstrap servers as CSV
-	if config.Kafka != nil {
-		config.Kafka.BootstrapServers = strings.Split(config.Kafka.BootstrapServersStr, ",")
-		if config.Kafka.Timeout == 0 {
-			config.Kafka.Timeout = defaultKafkaTimeout
+	if appConf.Kafka != nil {
+		appConf.Kafka.BootstrapServers = strings.Split(appConf.Kafka.BootstrapServersStr, ",")
+		if appConf.Kafka.Timeout == 0 {
+			appConf.Kafka.Timeout = defaultKafkaTimeout
 		}
 	}
 
 	ctx := context.Background()
-	logger.Infof("starting relay monitor for %s network", config.Network.Name)
-	m, err := monitor.New(ctx, config, zapLogger)
+	logger.Infof("starting relay monitor for %s network", appConf.Network.Name)
+	m, err := monitor.New(ctx, appConf, zapLogger)
 	if err != nil {
 		logger.Fatalf("could not start relay monitor: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ralexstokes/relay-monitor
 go 1.19
 
 require (
+	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/ethereum/go-ethereum v1.12.0
 	github.com/flashbots/go-boost-utils v1.6.0
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
@@ -13,6 +14,7 @@ require (
 	github.com/r3labs/sse/v2 v2.10.0
 	github.com/segmentio/kafka-go v0.4.43
 	go.uber.org/zap v1.24.0
+	gopkg.in/cenkalti/backoff.v1 v1.1.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -73,7 +75,6 @@ require (
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
-	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/bits-and-blooms/bitset v1.7.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edY
 github.com/btcsuite/btcd/btcec/v2 v2.3.2 h1:5n0X6hX0Zk+6omWcihdYvdAlGf2DfasC0GMf7DClJ3U=
 github.com/btcsuite/btcd/btcec/v2 v2.3.2/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
+github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
+github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/pkg/analysis/analyzer.go
+++ b/pkg/analysis/analyzer.go
@@ -40,11 +40,9 @@ type Analyzer struct {
 
 	output *output.Output
 	region string
-
-	timeout time.Duration
 }
 
-func NewAnalyzer(logger *zap.Logger, relays []*builder.Client, events <-chan data.Event, store store.Storer, consensusClient *consensus.Client, clock *consensus.Clock, output *output.Output, region string, timeout time.Duration) *Analyzer {
+func NewAnalyzer(logger *zap.Logger, relays []*builder.Client, events <-chan data.Event, store store.Storer, consensusClient *consensus.Client, clock *consensus.Clock, output *output.Output, region string) *Analyzer {
 	faults := make(FaultRecord)
 	for _, relay := range relays {
 		faults[relay.PublicKey] = &Faults{}
@@ -58,7 +56,6 @@ func NewAnalyzer(logger *zap.Logger, relays []*builder.Client, events <-chan dat
 		faults:          faults,
 		output:          output,
 		region:          region,
-		timeout:         timeout,
 	}
 }
 
@@ -143,9 +140,7 @@ func (a *Analyzer) outputValidationError(validationError *InvalidBid) {
 		if err != nil {
 			logger.Warnw("unable to marshal output", "error", err, "content", out)
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), a.timeout)
-		defer cancel()
-		err = a.output.WriteEntry(ctx, outBytes)
+		err = a.output.WriteEntry(outBytes)
 		if err != nil {
 			logger.Warnw("unable to write output", "error", err)
 		}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/ralexstokes/relay-monitor/pkg/analysis"
+	"github.com/ralexstokes/relay-monitor/pkg/config"
 	"github.com/ralexstokes/relay-monitor/pkg/consensus"
 	"github.com/ralexstokes/relay-monitor/pkg/crypto"
 	"github.com/ralexstokes/relay-monitor/pkg/data"
@@ -30,11 +31,6 @@ const (
 	DefaultEpochSpanForFaultsWindow = 256
 )
 
-type Config struct {
-	Host string `yaml:"host"`
-	Port uint16 `yaml:"port"`
-}
-
 type Span struct {
 	Start types.Epoch `json:"start_epoch,string"`
 	End   types.Epoch `json:"end_epoch,string"`
@@ -46,8 +42,8 @@ type FaultsResponse struct {
 }
 
 type Server struct {
-	config *Config
-	logger *zap.Logger
+	appConf *config.ApiConfig
+	logger  *zap.Logger
 
 	analyzer        *analysis.Analyzer
 	events          chan<- data.Event
@@ -56,9 +52,9 @@ type Server struct {
 	consensusClient *consensus.Client
 }
 
-func New(config *Config, logger *zap.Logger, analyzer *analysis.Analyzer, events chan<- data.Event, clock *consensus.Clock, store store.Storer, consensusClient *consensus.Client) *Server {
+func New(appConf *config.ApiConfig, logger *zap.Logger, analyzer *analysis.Analyzer, events chan<- data.Event, clock *consensus.Clock, store store.Storer, consensusClient *consensus.Client) *Server {
 	return &Server{
-		config:          config,
+		appConf:         appConf,
 		logger:          logger,
 		analyzer:        analyzer,
 		events:          events,
@@ -335,7 +331,7 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) Run(ctx context.Context) error {
 	logger := s.logger.Sugar()
-	host := fmt.Sprintf("%s:%d", s.config.Host, s.config.Port)
+	host := fmt.Sprintf("%s:%d", s.appConf.Host, s.appConf.Port)
 	logger.Infof("API server listening on %s", host)
 
 	mux := http.NewServeMux()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,9 +1,7 @@
-package monitor
+package config
 
 import (
 	"time"
-
-	"github.com/ralexstokes/relay-monitor/pkg/api"
 )
 
 type NetworkConfig struct {
@@ -25,11 +23,16 @@ type KafkaConfig struct {
 	Timeout             time.Duration `yaml:"timeout"`
 }
 
+type ApiConfig struct {
+	Host string `yaml:"host"`
+	Port uint16 `yaml:"port"`
+}
+
 type Config struct {
 	Network   *NetworkConfig   `yaml:"network"`
 	Consensus *ConsensusConfig `yaml:"consensus"`
 	Relays    []string         `yaml:"relays"`
-	Api       *api.Config      `yaml:"api"`
+	Api       *ApiConfig       `yaml:"api"`
 	Output    *OutputConfig    `yaml:"output"`
 	Region    string           `yaml:"region"`
 	Kafka     *KafkaConfig     `yaml:"kafka"`

--- a/pkg/consensus/client.go
+++ b/pkg/consensus/client.go
@@ -188,19 +188,6 @@ func (c *Client) LoadCurrentContext(ctx context.Context, currentSlot types.Slot,
 	}
 	b.Reset()
 
-	// err = backoff.Retry(func() error {
-	// 	err = c.FetchValidators(context.Background())
-	// 	if err != nil {
-	// 		logger.Infof("could not load validators: %v, retrying...", err)
-	// 		return err
-	// 	}
-	// 	return err
-	// }, b)
-	// if err != nil {
-	// 	return fmt.Errorf("could not load validators: %v", err)
-	// }
-	// b.Reset()
-
 	return nil
 }
 

--- a/pkg/consensus/client.go
+++ b/pkg/consensus/client.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/ethereum/go-ethereum/common/math"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/holiman/uint256"
@@ -155,21 +156,50 @@ func (c *Client) LoadCurrentContext(ctx context.Context, currentSlot types.Slot,
 		}
 	}
 
-	err := c.FetchProposers(ctx, currentEpoch)
+	// Start with default values for now, may need to update
+	b := backoff.NewExponentialBackOff()
+	b.MaxElapsedTime = time.Second * 60
+	b.Reset()
+
+	err := backoff.Retry(func() error {
+		err := c.FetchProposers(ctx, currentEpoch)
+		if err != nil {
+			logger.Info("could not load proposers, backing off an retrying")
+		}
+		return err
+	}, b)
 	if err != nil {
-		logger.Warnf("could not load consensus state for epoch %d: %v", currentEpoch, err)
+		return fmt.Errorf("could not load proposers: %v", err)
 	}
+
+	b.Reset()
 
 	nextEpoch := currentEpoch + 1
-	err = c.FetchProposers(ctx, nextEpoch)
+	err = backoff.Retry(func() error {
+		err = c.FetchProposers(ctx, nextEpoch)
+		if err != nil {
+			logger.Infof("could not load consensus state for epoch %d: %v", nextEpoch, err)
+			return err
+		}
+		return err
+	}, b)
 	if err != nil {
-		logger.Warnf("could not load consensus state for epoch %d: %v", nextEpoch, err)
+		return fmt.Errorf("could not load next epoch proposers: %v", err)
 	}
+	b.Reset()
 
-	err = c.FetchValidators(ctx)
-	if err != nil {
-		logger.Warnf("could not load validators: %v", err)
-	}
+	// err = backoff.Retry(func() error {
+	// 	err = c.FetchValidators(context.Background())
+	// 	if err != nil {
+	// 		logger.Infof("could not load validators: %v, retrying...", err)
+	// 		return err
+	// 	}
+	// 	return err
+	// }, b)
+	// if err != nil {
+	// 	return fmt.Errorf("could not load validators: %v", err)
+	// }
+	// b.Reset()
 
 	return nil
 }
@@ -260,7 +290,27 @@ func (c *Client) GetValidator(publicKey *types.PublicKey) (*eth2api.ValidatorRes
 
 	validator, ok := c.validatorCache[*publicKey]
 	if !ok {
-		return nil, fmt.Errorf("missing validator entry for public key %s", publicKey)
+
+		pubKeys, _ := publicKey.MarshalText()
+		var x common.BLSPubkey
+		err := x.UnmarshalText(pubKeys)
+		if err != nil {
+			return nil, err
+		}
+
+		filter := eth2api.ValidatorIdPubkey(x)
+		exists, err := beaconapi.StateValidator(context.Background(), c.client, eth2api.StateHead, filter, validator)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			return nil, fmt.Errorf("could not fetch validators from remote endpoint because they do not exist")
+		}
+
+		publicKey := validator.Validator.Pubkey
+		key := types.PublicKey(publicKey)
+		c.validatorCache[key] = validator
+		c.validatorIndexCache[uint64(validator.Index)] = &key
 	}
 	return validator, nil
 }
@@ -320,15 +370,30 @@ func (c *Client) FetchBlockRequest(ctx context.Context, slot types.Slot, dest *e
 func (c *Client) RetryBlockRequest(ctx context.Context, slot types.Slot, dest *eth2api.VersionedSignedBeaconBlock) error {
 	// Retry previous slot 5 times
 	logger := c.logger.Sugar()
-	for i := 1; i < 5; i++ {
-		logger.Warnf("could not find slot: %d. Retrying in %ds. Attempt %d", slot, i, i)
-		// Sleep and then retry in case it was a Node issue
-		time.Sleep(time.Duration(i) * time.Second)
+
+	b := backoff.NewExponentialBackOff()
+	b.MaxElapsedTime = time.Second * 12
+	b.InitialInterval = time.Second
+	b.Reset()
+
+	err := backoff.Retry(func() error {
+		logger.Warnf("could not find slot: %d. Retrying in %vs.", slot, b.NextBackOff().Seconds())
 		exists, err := c.FetchBlockRequest(ctx, slot, dest)
-		if exists && err == nil {
+		if err != nil {
 			return err
 		}
+
+		if exists {
+			return nil
+		} else {
+			return fmt.Errorf("could not find block for slot %d", slot)
+		}
+	}, b)
+
+	if err == nil {
+		return nil
 	}
+
 	// Try 3 previous slots
 	for i := 1; i < 4; i++ {
 		targetSlot := slot - uint64(i)
@@ -403,9 +468,9 @@ func (c *Client) StreamHeads(ctx context.Context) <-chan types.Coordinate {
 }
 
 // TODO handle reorgs
-func (c *Client) FetchValidators(ctx context.Context) error {
+func (c *Client) FetchValidators(ctx context.Context, validatorIds []eth2api.ValidatorId, statusFilter []eth2api.ValidatorStatus) error {
 	var response []eth2api.ValidatorResponse
-	exists, err := beaconapi.StateValidators(ctx, c.client, eth2api.StateHead, nil, nil, &response)
+	exists, err := beaconapi.StateValidators(ctx, c.client, eth2api.StateHead, validatorIds, statusFilter, &response)
 	if err != nil {
 		return err
 	}

--- a/pkg/data/collector.go
+++ b/pkg/data/collector.go
@@ -165,28 +165,10 @@ func (c *Collector) syncProposers(ctx context.Context) {
 	}
 }
 
-// func (c *Collector) syncValidators(ctx context.Context) {
-// 	logger := c.logger.Sugar()
-
-// 	epochs := c.clock.TickEpochs(ctx)
-// 	for {
-// 		select {
-// 		case <-ctx.Done():
-// 			return
-// 		case epoch := <-epochs:
-// 			err := c.consensusClient.FetchValidators(ctx)
-// 			if err != nil {
-// 				logger.Warnf("could not load validators in epoch %d: %v", epoch, err)
-// 			}
-// 		}
-// 	}
-// }
-
 // TODO refactor this into a separate component as the list of duties is growing outside the "collector" abstraction
 func (c *Collector) collectConsensusData(ctx context.Context) {
 	go c.syncBlocks(ctx)
 	go c.syncProposers(ctx)
-	// go c.syncValidators(ctx)
 }
 
 func (c *Collector) Run(ctx context.Context) error {


### PR DESCRIPTION
- Reduces load on the relay-monitor by querying validators on demand instead of querying the entire list. 